### PR TITLE
Added eligible users default as 90 days of active users

### DIFF
--- a/models/profiles-ml.yaml
+++ b/models/profiles-ml.yaml
@@ -21,7 +21,7 @@ models:
             prediction_horizon_days: 7 # Number of days in future for which we want to predict
             features_profiles_model: 'rudder_user_base_features' # Model name
             output_profiles_ml_model: *model_name_7_days # Name of output model based on current model to dinstinguish between multiple models
-            eligible_users:
+            eligible_users: days_since_last_seen<=90
             inputs:
               - packages/base_features/models/rudder_user_base_features
 
@@ -70,7 +70,7 @@ models:
             prediction_horizon_days: 30 # Number of days in future for which we want to predict
             features_profiles_model: 'rudder_user_base_features' # Model name
             output_profiles_ml_model: *model_name_30_days # Name of output model based on current model to dinstinguish between multiple models
-            eligible_users: 
+            eligible_users: days_since_last_seen<=90
             inputs:
               - packages/base_features/models/rudder_user_base_features
 
@@ -119,7 +119,7 @@ models:
             prediction_horizon_days: 90 # Number of days in future for which we want to predict
             features_profiles_model: 'rudder_user_base_features' # Model name
             output_profiles_ml_model: *model_name_90_days # Name of output model based on current model to dinstinguish between multiple models
-            eligible_users:
+            eligible_users: days_since_last_seen<=90
             inputs:
               - packages/base_features/models/rudder_user_base_features
 


### PR DESCRIPTION
## Description of the change

We often face lack of data error for 7 day churn with the current sample data. Modified the default eligible users to all users with any activity within past 90 days, which is reasonable default and also prevents the current errors. 

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
