### PR TITLE
Chore/reduce train file validity

### DIFF
--- a/models/profiles-ml.yaml
+++ b/models/profiles-ml.yaml
@@ -6,7 +6,7 @@ models:
       occurred_at_col: insert_ts
       entity_key: user
       validity_time: 24h # 1 day
-      py_repo_url: /Users/dileep/Library/CloudStorage/OneDrive-Personal/git_repos/rudderstack_profiles_classifier #git@github.com:rudderlabs/rudderstack-profiles-classifier.git
+      py_repo_url: git@github.com:rudderlabs/rudderstack-profiles-classifier.git
 
       train:
         file_extension: .json
@@ -55,7 +55,7 @@ models:
       occurred_at_col: insert_ts
       entity_key: user
       validity_time: 24h # 1 day
-      py_repo_url: /Users/dileep/Library/CloudStorage/OneDrive-Personal/git_repos/rudderstack_profiles_classifier #git@github.com:rudderlabs/rudderstack-profiles-classifier.git
+      py_repo_url: git@github.com:rudderlabs/rudderstack-profiles-classifier.git
 
       train:
         file_extension: .json
@@ -104,7 +104,7 @@ models:
       occurred_at_col: insert_ts
       entity_key: user
       validity_time: 24h # 1 day
-      py_repo_url: /Users/dileep/Library/CloudStorage/OneDrive-Personal/git_repos/rudderstack_profiles_classifier #git@github.com:rudderlabs/rudderstack-profiles-classifier.git
+      py_repo_url: git@github.com:rudderlabs/rudderstack-profiles-classifier.git
 
       train:
         file_extension: .json

--- a/models/profiles-ml.yaml
+++ b/models/profiles-ml.yaml
@@ -6,11 +6,11 @@ models:
       occurred_at_col: insert_ts
       entity_key: user
       validity_time: 24h # 1 day
-      py_repo_url: git@github.com:rudderlabs/rudderstack-profiles-classifier.git
+      py_repo_url: /Users/dileep/Library/CloudStorage/OneDrive-Personal/git_repos/rudderstack_profiles_classifier #git@github.com:rudderlabs/rudderstack-profiles-classifier.git
 
       train:
         file_extension: .json
-        file_validity: 168h # If the last trained model is older than this, then the model will be trained again,
+        file_validity: 0s # If the last trained model is older than this, then the model will be trained again,
         inputs: &inputs_7_days
           - models/rudder_user_base_features # inputs to materialise the required data for model
         config:
@@ -55,11 +55,11 @@ models:
       occurred_at_col: insert_ts
       entity_key: user
       validity_time: 24h # 1 day
-      py_repo_url: git@github.com:rudderlabs/rudderstack-profiles-classifier.git
+      py_repo_url: /Users/dileep/Library/CloudStorage/OneDrive-Personal/git_repos/rudderstack_profiles_classifier #git@github.com:rudderlabs/rudderstack-profiles-classifier.git
 
       train:
         file_extension: .json
-        file_validity: 168h # If the last trained model is older than this, then the model will be trained again,
+        file_validity: 0s # If the last trained model is older than this, then the model will be trained again,
         inputs: &inputs_30_days
           - models/rudder_user_base_features # inputs to materialise the required data for model
         config:
@@ -104,11 +104,11 @@ models:
       occurred_at_col: insert_ts
       entity_key: user
       validity_time: 24h # 1 day
-      py_repo_url: git@github.com:rudderlabs/rudderstack-profiles-classifier.git
+      py_repo_url: /Users/dileep/Library/CloudStorage/OneDrive-Personal/git_repos/rudderstack_profiles_classifier #git@github.com:rudderlabs/rudderstack-profiles-classifier.git
 
       train:
         file_extension: .json
-        file_validity: 168h # If the last trained model is older than this, then the model will be trained again,
+        file_validity: 0s # If the last trained model is older than this, then the model will be trained again,
         inputs: &inputs_90_days
           - models/rudder_user_base_features # inputs to materialise the required data for model
         config:


### PR DESCRIPTION
## Description of the change

On Prod, the current pb build does not support multiple python models if the training file validity is > 0s .so to enable demo videos, we are making it 0s as a temporary measure. Will revert once new release happens on prod and multiple py models are supported

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
